### PR TITLE
Introducing style property for shape

### DIFF
--- a/src/selection/rect_drag_selector.js
+++ b/src/selection/rect_drag_selector.js
@@ -255,29 +255,48 @@ annotorious.plugins.selection.RectDragSelector.prototype.getViewportBounds = fun
  * @param {boolean=} highlight if true, shape will be drawn highlighted
  */
 annotorious.plugins.selection.RectDragSelector.prototype.drawShape = function(g2d, shape, highlight) {
-  var geom, stroke, fill;
+  var geom, stroke, fill, outline;
   
   if (shape.type == annotorious.shape.ShapeType.RECTANGLE) {
-    if (highlight) {
-      g2d.lineWidth = 1.2;
-      stroke = this._HI_STROKE;
-      fill = this._HI_FILL;
+    if ('style' in shape) {
+        if (highlight) {
+          fill = shape.style.hi_fill;
+          stroke = shape.style.hi_stroke;
+          outline = shape.style.hi_outline;
+        } else {
+          fill = shape.style.fill;
+          stroke = shape.style.stroke;
+          outline = shape.style.outline;
+        }
     } else {
-      g2d.lineWidth = 1;
-      stroke = this._STROKE;
-      fill = this._FILL;
+        if (highlight) {
+          fill = this._HI_FILL;
+          stroke = this._HI_STROKE;
+          outline = this._OUTLINE;
+        } else {
+          fill = this._FILL;
+          stroke = this._STROKE;
+          outline = this._OUTLINE;
+        }
     }
+
+    if (highlight) { g2d.lineWidth = 1.2; }
+    else { g2d.lineWidth = 1; }
 
     geom = shape.geometry;
 
     // Outline
-    g2d.strokeStyle = this._OUTLINE;      
-    g2d.strokeRect(geom.x + 0.5, geom.y + 0.5, geom.width + 1, geom.height + 1);
+    if (outline) {
+        g2d.strokeStyle = outline;
+        g2d.strokeRect(geom.x + 0.5, geom.y + 0.5, geom.width + 1, geom.height + 1);
+    }
 
     // Stroke
-    g2d.strokeStyle = stroke;
-    g2d.strokeRect(geom.x + 1.5, geom.y + 1.5, geom.width - 1, geom.height - 1);
- 
+    if (stroke) {
+      g2d.strokeStyle = stroke;
+      g2d.strokeRect(geom.x + 1.5, geom.y + 1.5, geom.width - 1, geom.height - 1);
+    }
+
     // Fill   
     if (fill) {
       g2d.fillStyle = fill;

--- a/test/image/index.html
+++ b/test/image/index.html
@@ -14,7 +14,15 @@
           shapes: [{
             type: 'rect',
             units: 'pixel',
-            geometry: {x: 100, y: 80, width: 60, height: 50}
+            geometry: {x: 100, y: 80, width: 60, height: 50},
+            style: {
+                outline: '#ff0000',
+                hi_outline: '#00ff00',
+                stroke: '#0000ff',
+                hi_stroke: '#00ffff',
+                fill: 'rgba(0, 0, 255, 0.3)',
+                hi_fill: 'rgba(255, 0, 0, 0.3)'
+            }
           }]
         };
 


### PR DESCRIPTION
Now for each shape of an annotation the drawing color can be set in the shape.style property.

 In the drawShape() function, the selector will check the presence of the style property and if it is set it'll use the given style, otherwise it'll use the selector's configured style.
