### PR TITLE
Fix parenthesis in sanitizeCoordinates()

### DIFF
--- a/src/events.ui.js
+++ b/src/events.ui.js
@@ -41,7 +41,7 @@ annotorious.events.ui.sanitizeCoordinates = function(event, parent) {
   event.offsetX = (event.offsetX) ? event.offsetX : false;
   event.offsetY = (event.offsetY) ? event.offsetY : false;
   
-  if (!event.offsetX || !event.offsetY && event.event_.changedTouches) {
+  if ((!event.offsetX || !event.offsetY) && event.event_.changedTouches) {
     points = {
       x: event.event_.changedTouches[0].clientX - offset(parent).left,
       y: event.event_.changedTouches[0].clientY - offset(parent).top


### PR DESCRIPTION
The current parenthesis can cause exceptions.
Because due to the lack of parenthesis, if `offsetX = 0` then the whole expression is evaluated to true.
And in a desktop browser the `event_.changedTouches` is undefined, however we're trying to use 
`event.event_.changedTouches[0]` inside the if block which causes an exception.

This PR fixes this problem.
