### PR TITLE
Add API signals for when the editor gets shown and when the popup gets shown

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -115,6 +115,7 @@ annotorious.Editor.prototype.open = function(opt_annotation, opt_event) {
       goog.dom.appendChild(field.el, f);
     }
   });
+  this._annotator.fireEvent(annotorious.events.EventType.ANNOTATION_EDIT, opt_annotation);
 }
 
 /**

--- a/src/editor.js
+++ b/src/editor.js
@@ -115,7 +115,7 @@ annotorious.Editor.prototype.open = function(opt_annotation, opt_event) {
       goog.dom.appendChild(field.el, f);
     }
   });
-  this._annotator.fireEvent(annotorious.events.EventType.ANNOTATION_EDIT, opt_annotation);
+  this._annotator.fireEvent(annotorious.events.EventType.ANNOTATION_EDITOR_SHOWN, opt_annotation);
 }
 
 /**

--- a/src/events.js
+++ b/src/events.js
@@ -129,6 +129,11 @@ annotorious.events.EventType = {
   /**
    * An existing annotation was updated
    */
-  ANNOTATION_UPDATED: 'onAnnotationUpdated'
+  ANNOTATION_UPDATED: 'onAnnotationUpdated',
+  
+  /**
+   * The annotation editor was opened.  Pass the annotation object if it exists.
+   */
+  ANNOTATION_EDIT: 'onAnnotationEdit'
 
 };

--- a/src/events.js
+++ b/src/events.js
@@ -134,6 +134,11 @@ annotorious.events.EventType = {
   /**
    * The annotation editor was opened.  Pass the annotation object if it exists.
    */
-  ANNOTATION_EDIT: 'onAnnotationEdit'
+  ANNOTATION_EDITOR_SHOWN: 'onAnnotationEditorShown',
+  
+  /**
+   * The annotation popop was opened.  Pass the annotation object.
+   */
+  ANNOTATION_POPUP_SHOWN: 'onAnnotationPopupShown'
 
 };

--- a/src/popup.js
+++ b/src/popup.js
@@ -175,6 +175,7 @@ annotorious.Popup.prototype.show = function(annotation, xy) {
   
   goog.style.setOpacity(this.element, 0.9);
   goog.style.setStyle(this.element, 'pointer-events', 'auto');
+  this._annotator.fireEvent(annotorious.events.EventType.ANNOTATION_POPUP_SHOWN, annotation);
 }
 
 /**


### PR DESCRIPTION
Was necessary for my use case of doing an Angular compile when the editor or popup gets shown.  I feel these are generic enough for other users to benefit.
