### PR TITLE
OpenSeadragon fixes

### DIFF
--- a/src/mediatypes/openseadragon/openseadragon.annotator.js
+++ b/src/mediatypes/openseadragon/openseadragon.annotator.js
@@ -161,8 +161,9 @@ annotorious.mediatypes.openseadragon.OpenSeadragonAnnotator.prototype.fromItemCo
 }
 
 annotorious.mediatypes.openseadragon.OpenSeadragonAnnotator.prototype.getAnnotations = function() {
-
+  return this._viewer._overlays;
 }
+
 
 annotorious.mediatypes.openseadragon.OpenSeadragonAnnotator.prototype.getAvailableSelectors = function() {
 

--- a/src/mediatypes/openseadragon/openseadragon.viewer.js
+++ b/src/mediatypes/openseadragon/openseadragon.viewer.js
@@ -155,7 +155,7 @@ annotorious.mediatypes.openseadragon.Viewer.prototype.addAnnotation = function(a
     zIndex++;
   });
   
-  this._osdViewer.drawer.addOverlay(outer, rect);
+  this._osdViewer.addOverlay(outer, rect);
 }
 
 /**
@@ -165,11 +165,11 @@ annotorious.mediatypes.openseadragon.Viewer.prototype.addAnnotation = function(a
 annotorious.mediatypes.openseadragon.Viewer.prototype.removeAnnotation = function(annotation) {
   var overlay = goog.array.find(this._overlays, function(overlay) {
     return overlay.annotation == annotation;
-  }); 
+  });
 
   if (overlay) {
     goog.array.remove(this._overlays, overlay);
-    this._osdViewer.drawer.removeOverlay(overlay.outer);
+    this._osdViewer.removeOverlay(overlay.outer);
   }
 }
 
@@ -178,7 +178,7 @@ annotorious.mediatypes.openseadragon.Viewer.prototype.removeAnnotation = functio
  * @return {Array.<annotorious.Annotation>} the annotations
  */
 annotorious.mediatypes.openseadragon.Viewer.prototype.getAnnotations = function() {
-
+  return this._overlays;
 }
 
 /**


### PR DESCRIPTION
A few changes to improve compatability with OpenSeadragon:
- getAnnotations() is implemented
- add/removeAnnotation() edited to conform to the latest OpenSeadragon API. Specifically, viewer.addOverlay(), not viewer.drawer.addOverlay().
