### PR TITLE
Allow destroy of OpenSeadragon annotator

### DIFF
--- a/src/mediatypes/openseadragon/openseadragon.annotator.js
+++ b/src/mediatypes/openseadragon/openseadragon.annotator.js
@@ -104,6 +104,11 @@ annotorious.mediatypes.openseadragon.OpenSeadragonAnnotator.prototype.hideSelect
   // Does not have any effect at the moment
 }
 
+annotorious.mediatypes.openseadragon.OpenSeadragonAnnotator.prototype.destroy = function () {
+	this._viewer.destroy();
+	delete this._viewer;
+}
+
 annotorious.mediatypes.openseadragon.OpenSeadragonAnnotator.prototype.activateSelector = function(callback) {
   goog.style.setStyle(this._editCanvas, 'pointer-events', 'auto');
 

--- a/src/mediatypes/openseadragon/openseadragon.viewer.js
+++ b/src/mediatypes/openseadragon/openseadragon.viewer.js
@@ -117,7 +117,7 @@ annotorious.mediatypes.openseadragon.Viewer.prototype._updateHighlight = functio
  * Adds an annotation to the viewer.
  * @param {annotorious.Annotation} annotation the annotation
  */
-annotorious.mediatypes.openseadragon.Viewer.prototype.addAnnotation = function(annotation) {  
+annotorious.mediatypes.openseadragon.Viewer.prototype.addAnnotation = function(annotation) {
   var geometry = annotation.shapes[0].geometry;
   var outer = goog.dom.createDom('div', 'annotorious-ol-boxmarker-outer');
   var inner = goog.dom.createDom('div', 'annotorious-ol-boxmarker-inner');
@@ -154,7 +154,7 @@ annotorious.mediatypes.openseadragon.Viewer.prototype.addAnnotation = function(a
     goog.style.setStyle(overlay.outer, 'z-index', zIndex);
     zIndex++;
   });
-  
+
   this._osdViewer.addOverlay(outer, rect);
 }
 
@@ -188,4 +188,12 @@ annotorious.mediatypes.openseadragon.Viewer.prototype.getAnnotations = function(
  */
 annotorious.mediatypes.openseadragon.Viewer.prototype.highlightAnnotation = function(opt_annotation) {
 
+}
+
+annotorious.mediatypes.openseadragon.Viewer.prototype.destroy = function () {
+ var that = this;
+ goog.array.forEach(this._overlays, function (overlay) {
+   that._osdViewer.removeOverlay(overlay.outer);
+  });
+  this._overlays = [];
 }


### PR DESCRIPTION
This allows, for example anno.reset() to be called on an OpenSeadragon viewer.
