### PR TITLE
Use the current annotation in the POPUP_SHOWN event

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -175,7 +175,7 @@ annotorious.Popup.prototype.show = function(annotation, xy) {
   
   goog.style.setOpacity(this.element, 0.9);
   goog.style.setStyle(this.element, 'pointer-events', 'auto');
-  this._annotator.fireEvent(annotorious.events.EventType.POPUP_SHOWN, annotation);
+  this._annotator.fireEvent(annotorious.events.EventType.POPUP_SHOWN, this._currentAnnotation);
 }
 
 /**


### PR DESCRIPTION
Currently, when a popup is shown it is dependant on the popup.show() caller to include the current annotation in the method call. Neither OpenSeadragon.viewer nor OpenLayers.viewer do this. Instead they do:

``` js
  this._popup.setAnnotation(annotation);
  this._place_popup();
  this._popup.show();
```

This changes the event trigger to include use the currentAnnotation in the popup_shown event, rather than the passed in annotation.
