### PR TITLE
Add the stopSelection method to the global anno object

### DIFF
--- a/src/annotorious.js
+++ b/src/annotorious.js
@@ -253,6 +253,19 @@ annotorious.Annotorious.prototype.hideSelectionWidget = function(opt_item_url) {
   }
 }
 
+annotorious.Annotorious.prototype.stopSelection = function(opt_item_url) {
+  if (opt_item_url) {
+    var module = this._getModuleForItemSrc(opt_item_url);
+    if (module)
+      module.stopSelection(opt_item_url);
+  } else {
+    goog.array.forEach(this._modules, function(module) {
+      module.stopSelection();
+    });
+  }
+}
+
+
 /**
  * Highlights the specified annotation.
  * @param {annotorious.Annotation} annotation the annotation

--- a/src/mediatypes/module.js
+++ b/src/mediatypes/module.js
@@ -268,6 +268,18 @@ annotorious.mediatypes.Module.prototype.activateSelector = function(opt_item_url
   }
 }
 
+annotorious.mediatypes.Module.prototype.stopSelection = function(opt_item_url) {
+  if (opt_item_url) {
+    var annotator = this._annotators.get(opt_item_url);
+    if (annotator)
+      annotator.stopSelection();
+  } else {
+    goog.array.forEach(this._annotators.getValues(), function(annotator) {
+      annotator.stopSelection();
+    });
+  }
+}
+
 /**
  * Adds an annotation to an item managed by this module.
  * @param {annotorious.Annotation} annotation the annotation


### PR DESCRIPTION
This allows the selection process to be stopped from an external actor with

```
anno.hideSelectionWidget();
anno.stopSelection();
```
