### PR TITLE
Adding a beforeEditorShown event.

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -96,6 +96,8 @@ annotorious.Editor.prototype.addField = function(field) {
  * @param {Object=} opt_event the event, if any 
  */
 annotorious.Editor.prototype.open = function(opt_annotation, opt_event) {
+  this._annotator.fireEvent(annotorious.events.EventType.BEFORE_EDITOR_SHOWN, opt_annotation);
+
   this._original_annotation = opt_annotation;
   this._current_annotation = opt_annotation;
 

--- a/src/events.js
+++ b/src/events.js
@@ -104,7 +104,13 @@ annotorious.events.EventType = {
    * The current selection was changed
    */
   SELECTION_CHANGED: 'onSelectionChanged',
-  
+
+    
+  /**
+   * The annotation editor was opened.  Pass the annotation object if it exists.
+   */
+  BEFORE_EDITOR_SHOWN: 'beforeEditorShown',
+
   /**
    * The annotation editor was opened.  Pass the annotation object if it exists.
    */

--- a/src/events.js
+++ b/src/events.js
@@ -107,7 +107,7 @@ annotorious.events.EventType = {
 
     
   /**
-   * The annotation editor was opened.  Pass the annotation object if it exists.
+   * The annotation editor is opening.  Pass the annotation object if it exists.
    */
   BEFORE_EDITOR_SHOWN: 'beforeEditorShown',
 


### PR DESCRIPTION
This tool is great, thanks for all the hard work!

In our application, we'd like to be able to manipulate the text shown in the popup (remove/replace formatting, etc.) before presenting it to the user for their input. To accomplish this, I've added a beforeEditorShown event that is triggered when `Editor.open()` is called.

I'm happy to make any stylistic changes necessary to this PR, if it isn't quite right -- or feel free to close if there is a better way to accomplish what we're looking for. :)

Thanks!
