### PR TITLE
Exposed remove handler method

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -18,6 +18,7 @@ annotorious.Annotorious.prototype['setActiveSelector'] = annotorious.Annotorious
 annotorious.Annotorious.prototype['setProperties'] = annotorious.Annotorious.prototype.setProperties;
 annotorious.Annotorious.prototype['showAnnotations'] = annotorious.Annotorious.prototype.showAnnotations;
 annotorious.Annotorious.prototype['showSelectionWidget'] = annotorious.Annotorious.prototype.showSelectionWidget;
+annotorious.Annotorious.prototype['removeHandler'] = annotorious.Annotorious.prototype.removeHandler;
 
 /** Sets up the plugin namespace */
 if (!window['annotorious'])


### PR DESCRIPTION
In the PR #194 the **removeHandler** is added but is not exposed!
It should need to be exposed for using!